### PR TITLE
#3 - fix import and cleanup  RemovedInDjango19Warning

### DIFF
--- a/admin_tools/dashboard/modules.py
+++ b/admin_tools/dashboard/modules.py
@@ -5,7 +5,7 @@ Module where admin tools dashboard modules classes are defined.
 from django.utils.text import capfirst
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.utils.translation import ugettext_lazy as _
 from django.utils.itercompat import is_iterable
 

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/dashboard.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/dashboard.html
@@ -1,5 +1,4 @@
 {% load i18n admin_tools_dashboard_tags %}
-{% load url from future %}
 
 {% block dashboard_scripts %}
 <script type="text/javascript" src="{{ media_url }}/admin_tools/js/utils.js"></script>

--- a/admin_tools/menu/templates/admin_tools/menu/add_bookmark_form.html
+++ b/admin_tools/menu/templates/admin_tools/menu/add_bookmark_form.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% url 'admin-tools-menu-add-bookmark' as form_url %}
 {% if form_url %}
 <form id="bookmark-form" action="{{ form_url }}" method="POST">

--- a/admin_tools/menu/templates/admin_tools/menu/remove_bookmark_form.html
+++ b/admin_tools/menu/templates/admin_tools/menu/remove_bookmark_form.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% url 'admin-tools-menu-remove-bookmark' bookmark.id as form_url%}
 {% if form_url %}
 <form id="bookmark-form" action="{{ form_url }}" method="POST">

--- a/admin_tools/theming/templates/admin/base.html
+++ b/admin_tools/theming/templates/admin/base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load theming_tags %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ LANGUAGE_CODE }}" xml:lang="{{ LANGUAGE_CODE }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>


### PR DESCRIPTION
#3 - fix import and cleanup  RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated