### PR TITLE
admin: App title to be its verbose_name

### DIFF
--- a/admin_tools/dashboard/modules.py
+++ b/admin_tools/dashboard/modules.py
@@ -2,12 +2,14 @@
 Module where admin tools dashboard modules classes are defined.
 """
 
-from django.utils.text import capfirst
+from django.apps import apps as django_apps
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.forms.utils import flatatt
-from django.utils.translation import ugettext_lazy as _
+
 from django.utils.itercompat import is_iterable
+from django.utils.text import capfirst
+from django.utils.translation import ugettext_lazy as _
 
 from admin_tools.utils import AppListElementMixin, uniquify
 
@@ -444,12 +446,12 @@ class AppList(DashboardModule, AppListElementMixin):
             app_label = model._meta.app_label
             if app_label not in apps:
                 apps[app_label] = {
-                    'title': capfirst(app_label.title()),
+                    'title': django_apps.get_app_config(app_label).verbose_name,
                     'url': self._get_admin_app_list_url(model, context),
                     'models': []
                 }
             model_dict = {}
-            model_dict['title'] = capfirst(model._meta.verbose_name_plural)
+            model_dict['title'] = model._meta.verbose_name_plural
             if perms['change']:
                 model_dict['change_url'] = self._get_admin_change_url(model, context)
             if perms['add']:
@@ -532,7 +534,7 @@ class ModelList(DashboardModule, AppListElementMixin):
             return
         for model, perms in items:
             model_dict = {}
-            model_dict['title'] = capfirst(model._meta.verbose_name_plural)
+            model_dict['title'] = model._meta.verbose_name_plural
             if perms['change']:
                 model_dict['change_url'] = self._get_admin_change_url(model, context)
             if perms['add']:

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/dashboard.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/dashboard.html
@@ -52,7 +52,7 @@
 
 {% block dashboard_title %}
 {% if dashboard.title %}
-<h1 class="dashboard-title">{{ dashboard.title }}</h1>
+<h1 class="dashboard-title">{% trans dashboard.title|capfirst %}</h1>
 {% endif %}
 {% endblock %}
 
@@ -64,7 +64,7 @@
         {% spaceless %}
         {% for module in dashboard.children %}
         {% if not module.enabled %}
-        <li><a href="#" rel="module_{{ module.id }}" class="addlink add-dashboard-module">{{ module.title }}</a></li>
+        <li><a href="#" rel="module_{{ module.id }}" class="addlink add-dashboard-module">{% trans module.title|capfirst %}</a></li>
         {% endif %}
         {% endfor %}
         {% endspaceless %}

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/module.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/module.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% if not module.is_empty %}
     <div id="module_{{ module.id }}" class="{{ module.render_css_classes }}">
-        {% if module.show_title and module.title %}<h2>{% if module.title_url %}<a href="{{ module.title_url }}">{% trans module.title %}</a>{% else %}{% trans module.title %}{% endif %}</h2>{% endif %}
+        {% if module.show_title and module.title %}<h2>{% if module.title_url %}<a href="{{ module.title_url }}">{% trans module.title %}</a>{% else %}{% trans module.title|capfirst %}{% endif %}</h2>{% endif %}
         <div class="dashboard-module-content">
             {% spaceless %}
             {% if module.pre_content %}

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/modules/app_list.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/modules/app_list.html
@@ -2,12 +2,12 @@
 {% load i18n %}
 {% block module_content %}
         {% for child in module.children %}
-        <h3><a href="{{ child.url }}">{% trans child.title %}</a></h3>
+        <h3><a href="{{ child.url }}">{% trans child.title|capfirst %}</a></h3>
         <ul>
             {% for model in child.models %}
             {% spaceless %}
             <li>
-                {% if model.change_url %}<a href="{{ model.change_url }}">{{ model.title }}</a>{% else %}{{ model.title }}{% endif %}
+                {% if model.change_url %}<a href="{{ model.change_url }}">{% trans model.title|capfirst %}</a>{% else %}{% trans model.title|capfirst %}{% endif %}
                 {% if model.add_url or model.change_url %}
                 <ul>
                     {% if model.add_url %}<li><a class="addlink" href="{{ model.add_url }}"><span class="icon">{% trans "Add" %}</span></a></li>{% endif %}

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/modules/group.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/modules/group.html
@@ -1,18 +1,19 @@
 {% extends "admin_tools/dashboard/module.html" %}
 {% load admin_tools_dashboard_tags %}
+{% load i18n %}
 {% block module_content %}
 <div class="group group-{{ module.display }}">
     {% spaceless %}
     {% ifequal module.display "tabs" %}
     <ul>
     {% for sub_module in module.children %}
-        {% if not sub_module.is_empty %}<li class="group-tabs-link"><a href="#module_{{ sub_module.id }}">{{ sub_module.title }}</a></li>{% endif %}
+        {% if not sub_module.is_empty %}<li class="group-tabs-link"><a href="#module_{{ sub_module.id }}">{% trans sub_module.title|capfirst %}</a></li>{% endif %}
     {% endfor %}
     </ul>
     {% endifequal %}
     {% ifequal module.display "accordion" %}
     {% for sub_module in module.children %}
-        {% if not sub_module.is_empty %}<span class="group-accordion-header"><a href="#">{{ sub_module.title }}</a></span>{% endif %}
+        {% if not sub_module.is_empty %}<span class="group-accordion-header"><a href="#">{% trans sub_module.title|capfirst %}</a></span>{% endif %}
         {% admin_tools_render_dashboard_module sub_module %}
     {% endfor %}
     {% else %}

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/modules/link_list.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/modules/link_list.html
@@ -1,11 +1,12 @@
 {% extends "admin_tools/dashboard/module.html" %}
 {% load cycle from future %}
+{% load i18n %}
 {% block module_content %}
 <ul class="{{ module.layout }}">
     {% spaceless %}
     {% for child in module.children %}
     <li class="{% cycle 'odd' 'even' %}">
-    <a{{ child.attrs|safe }}>{{ child.title }}</a> 
+    <a{{ child.attrs|safe }}>{% trans child.title|capfirst %}</a> 
     </li>
     {% endfor %}
     {% endspaceless %}

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/modules/model_list.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/modules/model_list.html
@@ -5,7 +5,7 @@
             {% for child in module.children %}
             {% spaceless %}
             <li>
-                {% if child.change_url %}<a href="{{ child.change_url }}">{{ child.title }}</a>{% else %}{{ child.title }}{% endif %}
+                {% if child.change_url %}<a href="{{ child.change_url }}">{% trans child.title|capfirst %}</a>{% else %}{% trans child.title|capfirst %}{% endif %}
                 {% if child.add_url or child.change_url %}
                 <ul>
                     {% if child.add_url %}<li><a class="addlink" href="{{ child.add_url }}"><span class="icon">{% trans "Add" %}</span></a></li>{% endif %}

--- a/admin_tools/menu/templates/admin_tools/menu/item.html
+++ b/admin_tools/menu/templates/admin_tools/menu/item.html
@@ -2,7 +2,7 @@
 {% spaceless %}
 {% if not item.is_empty %}
 <li class="menu-item{% ifequal index 1 %} first{% endifequal %}{% if not item.enabled %} disabled{% endif %}{% if selected %} selected{% endif %}{% if item.css_classes %} {{ item.css_classes|join:' ' }}{% endif %}">
-<a href="{% if item.url and item.enabled %}{{ item.url }}{% else %}#{% endif %}"{% if item.description %} title="{{ item.description }}"{% endif %}{% if item.accesskey %} accesskey="{{ item.accesskey }}"{% endif %}>{% if item.children and item.enabled %}<span class="icon"></span>{% endif %}{% trans item.title %}</a>
+<a href="{% if item.url and item.enabled %}{{ item.url }}{% else %}#{% endif %}"{% if item.description %} title="{{ item.description }}"{% endif %}{% if item.accesskey %} accesskey="{{ item.accesskey }}"{% endif %}>{% if item.children and item.enabled %}<span class="icon"></span>{% endif %}{% trans item.title|capfirst %}</a>
     {% if item.children and item.enabled %}
     <ul>
         {% for child_item in item.children %}

--- a/admin_tools/menu/templates/admin_tools/menu/menu.html
+++ b/admin_tools/menu/templates/admin_tools/menu/menu.html
@@ -28,7 +28,7 @@
             {% if has_bookmark_item %}
                 process_bookmarks(
                    "{{ request.get_full_path }}",
-                   "{{ title }}",
+                   "{% trans title|capfirst %}",
                    "{% trans 'Please enter a name for the bookmark' %}"
                 );
             {% endif %}

--- a/admin_tools/theming/templates/admin/base.html
+++ b/admin_tools/theming/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load admin_static theming_tags %}{% load firstof from future %}<!DOCTYPE html>
+{% load admin_static i18n theming_tags %}{% load firstof from future %}<!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
 <title>{% block title %}{% endblock %}</title>
@@ -65,7 +65,7 @@
     <!-- Content -->
     <div id="content" class="{% block coltype %}colM{% endblock %}">
         {% block pretitle %}{% endblock %}
-        {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
+        {% block content_title %}{% if title %}<h1>{% trans title|capfirst %}</h1>{% endif %}{% endblock %}
         {% block content %}
         {% block object-tools %}{% endblock %}
         {{ content }}


### PR DESCRIPTION
- fixed #8
- also drop capfirst for module name, because it breaks trasnlation

Signed-off-by: Hiroshi Miura <miurahr@linux.com>