### PR TITLE
Some margin/clearfixes for django-flat-theme

### DIFF
--- a/admin_tools/menu/static/admin_tools/css/menu.css
+++ b/admin_tools/menu/static/admin_tools/css/menu.css
@@ -156,3 +156,7 @@
 #header ul#navigation-menu li.disabled a.over {
     background: none;
 }
+
+#content {
+    clear: both;
+}

--- a/admin_tools/theming/static/admin_tools/css/theming.css
+++ b/admin_tools/theming/static/admin_tools/css/theming.css
@@ -5,6 +5,11 @@
 
 #header {
     background: url(../images/admin-tools.png) 0 0 repeat-x;
+
+    /* Reset the indents of django-flat-theme
+      (need to restore 40px on branding+user-tools instead) */
+    padding-left: 0;
+    padding-right: 0;
 }
 
 #header #branding h1 {
@@ -14,6 +19,11 @@
     background: transparent url(../images/django.png) 10px 5px no-repeat;
     height: 31px;
     width: 93px;
+}
+
+#header #user-tools {
+    /* Old Django: 1.2em, flat theme: 40px; */
+    padding-right: 1.2em;
 }
 
 #bookmark-form {


### PR DESCRIPTION
This does not fix all CSS issues, but at least makes sure things don't fall apart.
This fixes floats not clearing, and resets margins of the `#header`.
The original Django theme is not affected by these changes.

To have full flat-theme support (which becomes the default in Django 1.9), the following would also be needed:
* Change padding-right of `#user-tools` to 40px.
* Rebuild the sprite with larger margins.
* Remove the header background image.
* Change the height/padding of the menu items to avoid looking crammed.

I've left these out on purpose, because those would affect the current styling too. Those changes can be found in a separate branch, that builds on top of this one (https://github.com/vdboor/django-admin-tools/tree/flat-theme)