### PR TITLE
Correct css inclusion example.

### DIFF
--- a/admin_tools/dashboard/dashboards.py
+++ b/admin_tools/dashboard/dashboards.py
@@ -43,7 +43,9 @@ class Dashboard(object):
 
         class MyDashboard(Dashboard):
             class Media:
-                css = ('css/mydashboard.css',)
+                css = {
+                    'text/css': ('css/mydashboard.css',),
+                }
                 js = ('js/mydashboard.js',)
 
     Here's an example of a custom dashboard::

--- a/admin_tools/dashboard/dashboards.py
+++ b/admin_tools/dashboard/dashboards.py
@@ -44,7 +44,7 @@ class Dashboard(object):
         class MyDashboard(Dashboard):
             class Media:
                 css = {
-                    'text/css': ('css/mydashboard.css',),
+                    'screen, projection': ('css/mydashboard.css',),
                 }
                 js = ('js/mydashboard.js',)
 


### PR DESCRIPTION
Confused me greatly trying to add css. Eventually gets eaten here: https://github.com/django-admin-tools/django-admin-tools/blob/e4caef85fd1438465b4879d885cb73d76e82b6ee/admin_tools/dashboard/templates/admin_tools/dashboard/css.html which expects a dict with media type.