### PR TITLE
Trust pre_content and post_content

### DIFF
--- a/admin_tools/dashboard/templates/admin_tools/dashboard/module.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/module.html
@@ -4,7 +4,7 @@
         <div class="dashboard-module-content">
             {% spaceless %}
             {% if module.pre_content %}
-            <p>{{ module.pre_content }}</p>
+            <p>{{ module.pre_content|safe }}</p>
             {% endif %}
             {% block module_content %}
             {% for child in module.children %}
@@ -12,7 +12,7 @@
             {% endfor %}
             {% endblock %}
             {% if module.post_content %}
-            <p>{{ module.post_content }}</p>
+            <p>{{ module.post_content|safe }}</p>
             {% endif %}
             {% endspaceless %}
         </div>


### PR DESCRIPTION
Docs say you can use html in these attributes. But the default template disagrees.

[Docs](https://django-admin-tools.readthedocs.org/en/latest/dashboard.html#the-dashboardmodule-class)

> Text or HTML content to display above the module content. Default value: `None`.