### PR TITLE
Handle CSRF for bookmarks,preferences ajax requests. Remove csrf_exempt from views.

### DIFF
--- a/admin_tools/dashboard/views.py
+++ b/admin_tools/dashboard/views.py
@@ -4,17 +4,11 @@ from django.template import RequestContext
 from django.shortcuts import render_to_response
 from django.contrib import messages
 
-try:
-    from django.views.decorators.csrf import csrf_exempt
-except ImportError:
-    from django.contrib.csrf.middleware import csrf_exempt
-
 from .forms import DashboardPreferencesForm
 from .models import DashboardPreferences
 
 
 @login_required
-@csrf_exempt
 def set_preferences(request, dashboard_id):
     """
     This view serves and validates a preferences form.

--- a/admin_tools/menu/views.py
+++ b/admin_tools/menu/views.py
@@ -4,17 +4,11 @@ from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
 from django.contrib import messages
 
-try:
-    from django.views.decorators.csrf import csrf_exempt
-except ImportError:
-    from django.contrib.csrf.middleware import csrf_exempt
-
 from .forms import BookmarkForm
 from .models import Bookmark
 
 
 @login_required
-@csrf_exempt
 def add_bookmark(request):
     """
     This view serves and validates a bookmark form.
@@ -46,7 +40,6 @@ def add_bookmark(request):
 
 
 @login_required
-@csrf_exempt
 def edit_bookmark(request, id):
     bookmark = get_object_or_404(Bookmark, id=id)
     if request.method == "POST":
@@ -71,7 +64,6 @@ def edit_bookmark(request, id):
 
 
 @login_required
-@csrf_exempt
 def remove_bookmark(request, id):
     """
     This view deletes a bookmark.

--- a/admin_tools/static/admin_tools/js/utils.js
+++ b/admin_tools/static/admin_tools/js/utils.js
@@ -1,3 +1,17 @@
+function isCsrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+function useCsrfTokens(){
+    // set CSRFToken header on POST requests (and remove the need for @csrf_exempt)
+    jQuery.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+            }
+        }
+    });
+}
 var loadScripts = function(js_files, onComplete){
     var len = js_files.length;
     var head = document.getElementsByTagName('head')[0];
@@ -6,6 +20,7 @@ var loadScripts = function(js_files, onComplete){
         var testOk;
 
         if (index >= len){
+            useCsrfTokens();
             onComplete();
             return;
         }

--- a/admin_tools/static/admin_tools/js/utils.js
+++ b/admin_tools/static/admin_tools/js/utils.js
@@ -1,6 +1,21 @@
-function isCsrfSafeMethod(method) {
+function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie != '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
 }
 function useCsrfTokens(){
     // set CSRFToken header on POST requests (and remove the need for @csrf_exempt)


### PR DESCRIPTION
Thanks for the great library!

This sets the CSRF token for the jquery ajax requests, removing the need to use the csrf_exempt decorator, improving security.