### PR TITLE
on_delete will be required when defining ForeignKey in Django 2.0

### DIFF
--- a/admin_tools/menu/models.py
+++ b/admin_tools/menu/models.py
@@ -16,7 +16,7 @@ class Bookmark(models.Model):
     """
     This model represents a user created bookmark.
     """
-    user = models.ForeignKey(user_model)
+    user = models.ForeignKey(user_model, on_delete=models.CASCADE)
     url = models.CharField(max_length=255)
     title = models.CharField(max_length=255)
 


### PR DESCRIPTION
`on_delete=models.CASCADE` is the default behaviour on Django 1.7 -> 1.9 and will be a required arg in Django 2.0