### PR TITLE
*admin* tool should require admin access

### DIFF
--- a/admin_tools/menu/views.py
+++ b/admin_tools/menu/views.py
@@ -46,7 +46,7 @@ def add_bookmark(request):
     )
 
 
-@login_required
+@staff_member_required
 @csrf_exempt
 def edit_bookmark(request, id):
     bookmark = get_object_or_404(Bookmark, id=id)
@@ -71,7 +71,7 @@ def edit_bookmark(request, id):
     )
 
 
-@login_required
+@staff_member_required
 @csrf_exempt
 def remove_bookmark(request, id):
     """

--- a/admin_tools/menu/views.py
+++ b/admin_tools/menu/views.py
@@ -1,4 +1,5 @@
-from django.contrib.auth.decorators import login_required
+
+from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
@@ -13,7 +14,7 @@ from .forms import BookmarkForm
 from .models import Bookmark
 
 
-@login_required
+@staff_member_required
 @csrf_exempt
 def add_bookmark(request):
     """


### PR DESCRIPTION
Users must have admin rights to be able to carry out any admin operations.
Use `@staff_member_required` instead of `@login_required`.