### PR TITLE
Handle when CustomUser.USERNAME_FIELD is set

### DIFF
--- a/admin_tools/dashboard/models.py
+++ b/admin_tools/dashboard/models.py
@@ -21,7 +21,7 @@ class DashboardPreferences(models.Model):
     dashboard_id = models.CharField(max_length=100)
 
     def __unicode__(self):
-        return "%s dashboard preferences" % self.user.username
+        return "%s dashboard preferences" % self.user.get_username()
 
     class Meta:
         db_table = 'admin_tools_dashboard_preferences'


### PR DESCRIPTION
There's a reference to `user.username`, which is incompatible with a user model that doesn't have a username attribute, e.g. where USERNAME_FIELD is set to `'email'`.

This causes a server error in my project when deleting a user. Fixed as in an earlier commit bf2d10264912e883ef06d297d5466d588f0aabf1, by calling `user.get_username()`.