### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,7 +25,7 @@ Version 0.7.0, 5 November 2015:
 * IMPORTANT INFORMATION, PLEASE READ: *
 
 Starting from this version (0.7.0) you must add ``admin_tools.template_loaders.Loader`` to your templates loaders variable in your settings file, see here for details:
-http://django-admin-tools.readthedocs.org/en/latest/configuration.html
+https://django-admin-tools.readthedocs.io/en/latest/configuration.html
 
 Change log:
 

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ The code is hosted on `Github <https://github.com/django-admin-tools/django-admi
 
 Django-admin-tools is generously documented, you can 
 `browse the documentation online 
-<http://django-admin-tools.readthedocs.org/>`_.
+<https://django-admin-tools.readthedocs.io/>`_.
 a good start is to read `the quickstart guide 
-<http://django-admin-tools.readthedocs.org/en/latest/quickstart.html>`_.
+<https://django-admin-tools.readthedocs.io/en/latest/quickstart.html>`_.
 
 The project was created by `David Jean Louis <http://www.izimobil.org/>`_ and was previously hosted on `Bitbucket <http://bitbucket.org/izi/django-admin-tools/>`_. 
 
@@ -61,13 +61,13 @@ Or if you'd prefer you can simply place the included "admin_tools" directory
 somewhere on your python path, or symlink to it from somewhere on your Python 
 path; this is useful if you're working from a Mercurial checkout.
 
-An `installation guide <http://django-admin-tools.readthedocs.org/en/latest/installation.html>`_ is available in the documentation.
+An `installation guide <https://django-admin-tools.readthedocs.io/en/latest/installation.html>`_ is available in the documentation.
 
 *************
 Documentation
 *************
 
-`Extensive documentation <http://django-admin-tools.readthedocs.org/>`_ is available, it was made with the excellent `Sphinx program <http://sphinx.pocoo.org/>`_
+`Extensive documentation <https://django-admin-tools.readthedocs.io/>`_ is available, it was made with the excellent `Sphinx program <http://sphinx.pocoo.org/>`_
 
 ************
 Translations

--- a/admin_tools/checks.py
+++ b/admin_tools/checks.py
@@ -5,7 +5,7 @@ from django.template.loader import get_template, TemplateDoesNotExist
 W001 = Warning(
     'You must add "admin_tools.template_loaders.Loader" in your '
     'template loaders variable, see: '
-    'https://django-admin-tools.readthedocs.org/en/latest/configuration.html',
+    'https://django-admin-tools.readthedocs.io/en/latest/configuration.html',
     id='admin_tools.W001',
     obj='admin_tools'
 )

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -14,7 +14,7 @@ There are various possibilities to get involved, for example you can:
 * `Discuss new features ideas 
   <http://groups.google.fr/group/django-admin-tools>`_
 * Fork the project, implement those features and send a pull request
-* Enhance the `documentation <http://django-admin-tools.readthedocs.org/en/latest/>`_
+* Enhance the `documentation <https://django-admin-tools.readthedocs.io/en/latest/>`_
 * `Translate django-admin-tools 
   <https://www.transifex.net/projects/p/django-admin-tools/c/admin_tools/>`_ 
   in your language


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.