### PR TITLE
Add app config with labels to avoid name collisions

### DIFF
--- a/admin_tools/dashboard/apps.py
+++ b/admin_tools/dashboard/apps.py
@@ -1,0 +1,6 @@
+# coding: utf-8
+from django.apps import AppConfig
+
+
+class DashboardConfig(AppConfig):
+    name = 'admin_tools.dashboard'

--- a/admin_tools/menu/apps.py
+++ b/admin_tools/menu/apps.py
@@ -1,0 +1,6 @@
+# coding: utf-8
+from django.apps import AppConfig
+
+
+class MenuConfig(AppConfig):
+    name = 'admin_tools.menu'

--- a/admin_tools/theming/apps.py
+++ b/admin_tools/theming/apps.py
@@ -1,0 +1,6 @@
+# coding: utf-8
+from django.apps import AppConfig
+
+
+class ThemingConfig(AppConfig):
+    name = 'admin_tools.theming'


### PR DESCRIPTION
This changes allow to fix potential `ImproperlyConfigured` issue with application labels collision.

Given I have an app with `dashboard` label, this configuration
```
INSTALLED_APPS = [
    ...
    'apps.dashboard',
    ...
   'admin_tools.dashboard',
]
```
produces `django.core.exceptions.ImproperlyConfigured: Application labels aren't unique, duplicates: dashboard`.

Django gives 3rd-party app authors to work around this using app configs, so app users can override app labels for installed app: https://docs.djangoproject.com/en/1.11/ref/applications/#for-application-authors

This is how user's code looks after collision is fixed, using this PR:
```
# settings.py
INSTALLED_APPS = [
    'apps.dashboard',
    ...
    'myproject.apps.AdminToolsDashboard',
    ...

# myproject/apps.py
from admin_tools.dashboard import apps 

class AdminToolsDashboard(apps.DashboardConfig):
    label = 'admin_tools_dashboard'
```

Sure enough, users can customize their own apps config to avoid conflict, but this may be cumbersome if they already have migrations.