### PR TITLE
Fix invalid reference in docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -30,7 +30,7 @@ your django admin site, if you didn't, please refer to the
 Required settings
 ~~~~~~~~~~~~~~~~~
 
-First make sure you have the ``django.core.context_processors.request``
+First make sure you have the ``django.template.context_processors.request``
 template context processor in your ``TEMPLATE_CONTEXT_PROCESSORS`` or
 ``TEMPLATES`` settings variable
 


### PR DESCRIPTION
update path to Django template request context processor
https://docs.djangoproject.com/en/3.0/releases/1.8/#django-core-context-processors