### PR TITLE
setting default_auto_field in AppConfig

### DIFF
--- a/admin_tools/apps.py
+++ b/admin_tools/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class AdminToolsConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'admin_tools'
 
     def ready(self):

--- a/admin_tools/dashboard/apps.py
+++ b/admin_tools/dashboard/apps.py
@@ -3,4 +3,5 @@ from django.apps import AppConfig
 
 
 class DashboardConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'admin_tools.dashboard'

--- a/admin_tools/menu/apps.py
+++ b/admin_tools/menu/apps.py
@@ -3,4 +3,5 @@ from django.apps import AppConfig
 
 
 class MenuConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'admin_tools.menu'

--- a/admin_tools/theming/apps.py
+++ b/admin_tools/theming/apps.py
@@ -3,4 +3,5 @@ from django.apps import AppConfig
 
 
 class ThemingConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'admin_tools.theming'


### PR DESCRIPTION
to avoid unnecessary migrations with Django 3.2 as the default will change to `BigAutoField`