### PR TITLE
docs: Fix a few typos

### DIFF
--- a/admin_tools/utils.py
+++ b/admin_tools/utils.py
@@ -86,9 +86,9 @@ def filter_models(request, models, exclude):
     def full_name(model):
         return '%s.%s' % (model.__module__, model.__name__)
 
-    # I beleive that that implemented
+    # I believe that that implemented
     # O(len(patterns)*len(matched_patterns)*len(all_models))
-    # algorythm is fine for model lists because they are small and admin
+    # algorithm is fine for model lists because they are small and admin
     # performance is not a bottleneck. If it is not the case then the code
     # should be optimized.
 


### PR DESCRIPTION
There are small typos in:
- admin_tools/utils.py

Fixes:
- Should read `believe` rather than `beleive`.
- Should read `algorithm` rather than `algorythm`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md