### PR TITLE
dummy.html: add default to satisfy django-compressor

### DIFF
--- a/admin_tools/dashboard/templates/admin_tools/dashboard/dummy.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/dummy.html
@@ -1,1 +1,1 @@
-{% extends template %}
+{% extends template|default:'admin_tools/dashboard/css.html' %}

--- a/admin_tools/menu/templates/admin_tools/menu/dummy.html
+++ b/admin_tools/menu/templates/admin_tools/menu/dummy.html
@@ -1,1 +1,1 @@
-{% extends template %}
+{% extends template|default:'admin_tools/dashboard/css.html' %}


### PR DESCRIPTION
Without this I got following error for django-compressor management command:

```
# poetry run python manage.py compress
Error parsing template admin_tools/dashboard/dummy.html: Invalid template name in 'extends' tag: ''. Got this from the 'template' variable.
Error parsing template admin_tools/menu/dummy.html: Invalid template name in 'extends' tag: ''. Got this from the 'template' variable.
```