### PR TITLE
Django 6 compatibility fix

### DIFF
--- a/admin_tools/dashboard/modules.py
+++ b/admin_tools/dashboard/modules.py
@@ -6,14 +6,10 @@ from django.apps import apps as django_apps
 try:
     # we use django.urls import as version detection as it will fail on django 1.11 and thus we are safe to use
     # gettext_lazy instead of ugettext_lazy instead
-    from django.urls import reverse
     from django.utils.translation import gettext_lazy as _
 except ImportError:
-    from django.core.urlresolvers import reverse
     from django.utils.translation import ugettext_lazy as _
 from django.forms.utils import flatatt
-from django.utils.itercompat import is_iterable
-from django.utils.text import capfirst
 
 from admin_tools.utils import AppListElementMixin, uniquify
 


### PR DESCRIPTION
- Django 6 compatibility fix from django 6.0 Release notes: https://docs.djangoproject.com/en/6.0/releases/6.0/
The undocumented django.utils.itercompat.is_iterable() function and the django.utils.itercompat module are removed.
- I removed unused declarations too